### PR TITLE
Fix inline JS when used split chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "10up-toolkit": "^5.0.0",
-        "html-bundler-webpack-plugin": "^1.2.0"
+        "html-bundler-webpack-plugin": "^1.6.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8993,9 +8993,9 @@
       }
     },
     "node_modules/html-bundler-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-chPP6DamfsnZvRp+wZSaVTd+UgGzhNtCCnosCoCV6QszjM96c7eqvt3ldcEH35CS+mEyX5jJNm9KEqAM3erPYw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-1.6.1.tgz",
+      "integrity": "sha512-29uR39xkUr6ZrNocwuU1A+yrvOzlAs54vxI6Y9mHPD/QKGF0kpwagITf5gb9psnmK4tyxpx+nMKPaJWKcnBnOw==",
       "dev": true,
       "dependencies": {
         "ansis": "1.5.5",
@@ -24791,9 +24791,9 @@
       }
     },
     "html-bundler-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-chPP6DamfsnZvRp+wZSaVTd+UgGzhNtCCnosCoCV6QszjM96c7eqvt3ldcEH35CS+mEyX5jJNm9KEqAM3erPYw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-1.6.1.tgz",
+      "integrity": "sha512-29uR39xkUr6ZrNocwuU1A+yrvOzlAs54vxI6Y9mHPD/QKGF0kpwagITf5gb9psnmK4tyxpx+nMKPaJWKcnBnOw==",
       "dev": true,
       "requires": {
         "ansis": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "10up-toolkit": "^5.0.0",
-    "html-bundler-webpack-plugin": "^1.2.0"
+    "html-bundler-webpack-plugin": "^1.6.1"
   },
   "browserslist": {
     "production": [

--- a/src/examples/illustration/line-drawing/css/index.html
+++ b/src/examples/illustration/line-drawing/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -68,6 +68,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/illustration/line-drawing/gsap/index.html
+++ b/src/examples/illustration/line-drawing/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -68,6 +68,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/illustration/line-drawing/waapi/index.html
+++ b/src/examples/illustration/line-drawing/waapi/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -68,6 +68,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/illustration/masking/css/index.html
+++ b/src/examples/illustration/masking/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -22,6 +22,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/illustration/masking/gsap/index.html
+++ b/src/examples/illustration/masking/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -22,6 +22,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/illustration/masking/waapi/index.html
+++ b/src/examples/illustration/masking/waapi/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -22,6 +22,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/accordion/css/index.html
+++ b/src/examples/ui/accordion/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -35,6 +35,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/accordion/gsap/index.html
+++ b/src/examples/ui/accordion/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -35,6 +35,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/full-screen/css/index.html
+++ b/src/examples/ui/menu/full-screen/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/full-screen/gsap/index.html
+++ b/src/examples/ui/menu/full-screen/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/full-screen/waapi/index.html
+++ b/src/examples/ui/menu/full-screen/waapi/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/off-screen/css/index.html
+++ b/src/examples/ui/menu/off-screen/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/off-screen/gsap/index.html
+++ b/src/examples/ui/menu/off-screen/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/menu/off-screen/waapi/index.html
+++ b/src/examples/ui/menu/off-screen/waapi/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -80,6 +80,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/css/about-us.html
+++ b/src/examples/ui/page-transition/css/about-us.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/css/contact-us.html
+++ b/src/examples/ui/page-transition/css/contact-us.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/css/index.html
+++ b/src/examples/ui/page-transition/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -42,6 +42,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/css/services.html
+++ b/src/examples/ui/page-transition/css/services.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/gsap/about-us.html
+++ b/src/examples/ui/page-transition/gsap/about-us.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/gsap/contact-us.html
+++ b/src/examples/ui/page-transition/gsap/contact-us.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/gsap/index.html
+++ b/src/examples/ui/page-transition/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -42,6 +42,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/page-transition/gsap/services.html
+++ b/src/examples/ui/page-transition/gsap/services.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 		</main>
 		<div id="overlay" class="overlay transition-overlay"></div>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/parallax/css/index.html
+++ b/src/examples/ui/parallax/css/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/src/examples/ui/parallax/gsap/index.html
+++ b/src/examples/ui/parallax/gsap/index.html
@@ -6,9 +6,9 @@
         <title>Parcel Boilerplate</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="../../../../assets/css/base.css?inline">
+        <link rel="stylesheet" href="@styles/base.css">
 		<!-- Example Specific -->
-		<link rel="stylesheet" href="index.css?inline">
+		<link rel="stylesheet" href="index.css">
     </head>
     <body>
 
@@ -40,6 +40,6 @@
 			</div>
 		</main>
 
-		<script type="module" src="index.js?inline"></script>
+		<script type="module" src="index.js"></script>
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,9 @@ examples.forEach(({path}) => {
     entries[key] = value;
 })
 
+// Use the alias instead of a relative path like '../../../../assets/css/'
+toolkitConfig.resolve.alias['@styles'] = path.join(__dirname, 'src/assets/css/')
+
 const config = {
     ...toolkitConfig,
     output: {
@@ -29,10 +32,6 @@ const config = {
         ...toolkitConfig.module,
         // Many of toolkits rules will collide and cause issues with this loader, so we're omitting using them here.
         rules: [
-            {
-                test: /\.html$/,
-                loader: HtmlBundlerPlugin.loader,
-            },
             {
                 test: /\.css$/,
                 use: [
@@ -54,19 +53,27 @@ const config = {
                 ],
             },
             {
-				test: /\.svg$/,
-				use: ['@svgr/webpack', 'url-loader'],
-			},
+                test: /\.svg$/,
+                // No need to use the deprecated 'url-loader'.
+                // The HtmlBundlerPlugin automaticaly transforms inlined SVG into utf8 data-URI in CSS.
+                use: ['@svgr/webpack'],
+            },
             {
-				test: /\.(jpg|jpeg|png|giff|webp)(\?v=\d+\.\d+\.\d+)?$/,
-				type: 'asset/inline',
-			},
+                test: /\.(jpg|jpeg|png|giff|webp)(\?v=\d+\.\d+\.\d+)?$/,
+                type: 'asset/inline',
+            },
         ],
     },
     // We should only need this for a plugin to process all our files due to how it handles assets.
     plugins: [
         new HtmlBundlerPlugin({
-            entry: entries
+            entry: entries,
+            js: {
+                inline: true, // globally inline all extracted JS
+            },
+            css: {
+                inline: true, // globally inline all extracted CSS
+            }
         }),
     ],
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

Hello @Firestorm980,

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) which is used in this repo.
I discovered that here is used old `1.2.0` version. This version have the issue: when in Webpack config used `splitChunks` then slitted  JS files will not be correctly inlined.

In the new version `1.6.1` this issue is fixed.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

- Update `html-bundler-webpack-plugin` from `1.2.0` to `1.6.1` (latest)

- Update Webpack config:
   - remove the `HtmlBundlerPlugin.loader` from `module.rules` because this is default loader of the plugin, no need to define it
   - define Webpack alias `@styles` as the path to the `src/assets/css/` directory to avoid using a relative path like `../../../../assets/css/`
   - remove deprecated 'url-loader'. The HtmlBundlerPlugin automaticaly transforms inlined SVG into utf8 data-URI in CSS.
   - add the `js.inline: true` and `css.inline: true` plugin options to globally inline all JS and CSS, without having to define `?inline` at every JS/CSS file

- In every HTML file was removed all `?inline` because all files can be inlined using global options `js.inline` and `css.inline` in Webpack config. 

- In every HTML file was replaced all relative paths like `../../../../assets/css/base.css` with the alias `@styles/base.css`.

> **Note**
>
> The `inline` plugin option can take following values:
> - `false` - extract processed file in an output file, defaults
>  - `true` - inline processed file into HTML
>  - `'auto'` - in `development` mode - inline a file, in `production` mode - extract in a file

I have manually tested all the example pages in the browser.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
+ Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
