### PR TITLE
Fix: Menu off screen

### DIFF
--- a/src/examples/ui/menu/off-screen/gsap/index.css
+++ b/src/examples/ui/menu/off-screen/gsap/index.css
@@ -24,7 +24,6 @@
 	padding: 1rem 1rem 2rem;
 	position: absolute;
 	top: 0;
-	transform: translateX(-100%);
 	visibility: hidden;
 	width: 100%;
 }

--- a/src/examples/ui/menu/off-screen/gsap/index.js
+++ b/src/examples/ui/menu/off-screen/gsap/index.js
@@ -17,7 +17,7 @@ const handleButtonOnClick = () => {
     // Open
     const tl = gsap.timeline()
 
-    tl.fromTo(menu, { autoAlpha: 0 }, { autoAlpha: 1, xPercent: 0, duration: 0.3, ease: 'power1.out' }, 'start')
+    tl.to(menu, { autoAlpha: 1, xPercent: 0, duration: 0.3, ease: 'power1.out' }, 'start')
     tl.to('.navigation--primary li', { opacity: 1, x: '0em', duration: 0.3, ease: 'power1.inOut', stagger: 0.1 }, 'start')
     tl.to('.navigation--secondary li', { opacity: 1, x: '0em', duration: 0.3, ease: 'power1.inOut' })
   }
@@ -30,6 +30,7 @@ const handleButtonOnClick = () => {
 }
 
 const setup = () => {
+  gsap.set(menu, { autoAlpha: 0, xPercent: -100 })
   menu.setAttribute('data-open', false)
   menu.setAttribute('aria-hidden', true)
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. `npm install`
2. `npm run watch`
3. Go to http://localhost:5000/examples/ui/menu/off-screen/gsap/

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Fixed an issue with the GSAP version of the menu.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
@Firestorm980 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
